### PR TITLE
remove CNY from surrencyArray

### DIFF
--- a/ByteCoin/Model/CoinManager.swift
+++ b/ByteCoin/Model/CoinManager.swift
@@ -13,7 +13,7 @@ struct CoinManager {
     let baseURL = "https://rest.coinapi.io/v1/exchangerate/BTC"
     let apiKey = "0D68574D-46EE-4216-A6EB-806A274ABB83"
     
-    let currencyArray = ["AUD", "BRL","CAD","CNY","EUR","GBP","HKD","IDR","ILS","INR","JPY","MXN","NOK","NZD","PLN","RON","RUB","SEK","SGD","USD","ZAR"]
+    let currencyArray = ["AUD", "BRL","CAD","EUR","GBP","HKD","IDR","ILS","INR","JPY","MXN","NOK","NZD","PLN","RON","RUB","SEK","SGD","USD","ZAR"]
     // TODO CNY is not recognized
 
     func getCoinPrice(for currency: String){


### PR DESCRIPTION
since CNY is not recognized by the coinAPI then I need to delete it from the currencyArray to avoid error'

the update is tested and there is no problem. All other currencies give data response per request. 